### PR TITLE
Parse URL Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,26 @@ cabal install heroku-persistent
 
 Adjusting the [Yesod][] scaffold to run on Heroku:
 
-**Application.hs**:
+**config/settings.yml**
+
+``` yaml
+database-url: "_env:DATABASE_URL:postgres://user:pass@localhost:5432/dbname"
+database-pool-size: "_env:DB_POOL:5"
+```
+
+**Settings.hs**:
 
 ```haskell
-import Web.Heroku.Persist.Postgresql (postgresConf)
+import Web.Heroku.Persist.Postgresql (fromDatabaseUrl)
 
-makeFoundation :: AppConfig DefaultEnv Extra -> IO App
-makeFoundation conf = do
-    -- ...
+instance FromJSON AppSettings where
+    parseJSON = withObject "AppSettings" $ \o -> do
+        appDatabaseConf <- fromDatabaseUrl
+                             <$> o .: "database-pool-size"
+                             <*> o .: "database-url"
+        -- ...
 
-    dbconf <- postgresConf 10
-
-    p <- Database.Persist.createPoolConfig (dbconf :: Settings.PersistConf)
-
-    -- ...
+        return AppSettings {..}
 ```
 
 [yesod]: http://www.yesodweb.com

--- a/src/Web/Heroku/Persist/Postgresql.hs
+++ b/src/Web/Heroku/Persist/Postgresql.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Web.Heroku.Persist.Postgresql
     ( postgresConf
+    , fromDatabaseUrl
     ) where
 
 import Control.Applicative ((<$>))
@@ -10,10 +11,11 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Monoid ((<>))
 import Database.Persist.Postgresql (PostgresConf(..))
 import Web.Heroku (dbConnParams)
+import Web.Heroku.Postgres (dbConnParams, parseDatabaseUrl)
 
 import qualified Data.Text as T
 
--- | Build a @'PostgresConf'@ by parsing @DATABASE_URL@
+-- | Build a @'PostgresConf'@ by parsing @ENV[DATABASE_URL]@
 postgresConf :: Int -> IO PostgresConf
 postgresConf size = do
     connStr <- formatParams <$> dbConnParams
@@ -22,6 +24,13 @@ postgresConf size = do
         { pgConnStr = connStr
         , pgPoolSize = size
         }
+
+-- | Build a @'PostgresConf'@ by parsing a database URL String
+fromDatabaseUrl :: Int -> String -> PostgresConf
+fromDatabaseUrl size url = PostgresConf
+    { pgConnStr = formatParams $ parseDatabaseUrl url
+    , pgPoolSize = size
+    }
 
 formatParams :: [(Text, Text)] -> ByteString
 formatParams = encodeUtf8 . T.unwords . map toKeyValue

--- a/test/Web/Heroku/Persist/PostgresqlSpec.hs
+++ b/test/Web/Heroku/Persist/PostgresqlSpec.hs
@@ -11,12 +11,19 @@ main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec =
+spec = do
   describe "postgresConf" $
     it "should parse a PostgresConf out of DATABASE_URL" $ do
         setEnv "DATABASE_URL" "postgres://user:password@host:1234/db"
 
         conf <- postgresConf 10
+
+        pgConnStr conf `shouldBe`
+            "user=user password=password host=host port=1234 dbname=db"
+        pgPoolSize conf `shouldBe` 10
+  describe "fromDatabaseUrl" $
+    it "should parse a PostgresConf out of a String" $ do
+        let conf = fromDatabaseUrl 10 "postgres://user:password@host:1234/db"
 
         pgConnStr conf `shouldBe`
             "user=user password=password host=host port=1234 dbname=db"


### PR DESCRIPTION
In newer versions of Yesod, environment variables can be read in
`settings.yml`, meaning we no longer need to parse the app settings in
IO.

Exposing a non-IO function to parse a database URL lets users take
advantage of this new feature in `Settings.hs`.
