### PR TITLE
Parse Text in addition to ByteString

### DIFF
--- a/persistent-database-url.cabal
+++ b/persistent-database-url.cabal
@@ -26,6 +26,7 @@ library
                       , persistent-postgresql >= 1.0.0
                       , uri-bytestring
                       , fail
+                      , string-conversions
 
 test-suite spec
   type:                 exitcode-stdio-1.0
@@ -37,6 +38,8 @@ test-suite spec
                       , hspec
                       , persistent-database-url
                       , persistent-postgresql
+                      , bytestring
+                      , text
 
 source-repository head
   type:                 git

--- a/src/Database/Persist/URL.hs
+++ b/src/Database/Persist/URL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Database.Persist.URL
     ( fromDatabaseUrl
@@ -7,6 +8,8 @@ import Control.Monad (unless)
 import Control.Monad.Fail (MonadFail)
 import Data.ByteString (ByteString, uncons)
 import Data.Monoid ((<>))
+import Data.String.Conversions (ConvertibleStrings(..))
+import Data.String.Conversions.Monomorphic (toStrictByteString)
 import Database.Persist.Postgresql (PostgresConf(..))
 import URI.ByteString
     ( Authority(..)
@@ -22,9 +25,11 @@ import URI.ByteString
 import qualified Data.ByteString.Char8 as Char8
 
 -- | Build a @'PostgresConf'@ by parsing a database URL String
-fromDatabaseUrl :: MonadFail m => Int -> ByteString -> m PostgresConf
+fromDatabaseUrl
+    :: (MonadFail m, ConvertibleStrings s ByteString)
+    => Int -> s -> m PostgresConf
 fromDatabaseUrl size url = do
-    uri <- abortLeft $ parseURI strictURIParserOptions url
+    uri <- abortLeft $ parseURI strictURIParserOptions $ toStrictByteString url
     auth <- abortNothing "authority" $ uriAuthority uri
     userInfo <- abortNothing "user info" $ authorityUserInfo auth
     port <- abortNothing "port" $ authorityPort auth

--- a/test/Database/Persist/URLSpec.hs
+++ b/test/Database/Persist/URLSpec.hs
@@ -3,6 +3,8 @@ module Database.Persist.URLSpec (main, spec) where
 
 import Test.Hspec
 import Database.Persist.URL
+import Data.ByteString (ByteString)
+import Data.Text (Text)
 
 import Database.Persist.Postgresql (PostgresConf(..))
 
@@ -12,25 +14,33 @@ main = hspec spec
 spec :: Spec
 spec =
   describe "fromDatabaseUrl" $ do
-    it "should parse a PostgresConf out of a String" $ do
-        let conf = fromDatabaseUrl 10 "postgres://user:password@host:1234/db"
+    it "should parse a PostgresConf out of a ByteString" $ do
+        let url = "postgres://user:password@host:1234/db" :: ByteString
+        let conf = fromDatabaseUrl 10 url
+
+        pgConnStr <$> conf `shouldBe`
+            Just "user=user password=password host=host port=1234 dbname=db"
+        pgPoolSize <$> conf `shouldBe` Just 10
+    it "should parse a PostgresConf out of a Text" $ do
+        let url = "postgres://user:password@host:1234/db" :: Text
+        let conf = fromDatabaseUrl 10 url
 
         pgConnStr <$> conf `shouldBe`
             Just "user=user password=password host=host port=1234 dbname=db"
         pgPoolSize <$> conf `shouldBe` Just 10
     it "should handle an invalid URL" $
-        fromDatabaseUrl 10 "postgres://user:password@/db"
+        fromDatabaseUrl 10 ("postgres://user:password@/db" :: ByteString)
             `shouldThrow`
                 (== userError "DATABASE_URL failed to parse: MalformedPath")
     it "should handle a missing authority" $
-        fromDatabaseUrl 10 "postgres:/db"
+        fromDatabaseUrl 10 ("postgres:/db" :: ByteString)
             `shouldThrow` (== userError "DATABASE_URL is missing authority")
     it "should handle a missing path" $
-        fromDatabaseUrl 10 "postgres://user:password@example:123"
+        fromDatabaseUrl 10 ("postgres://user:pass@example:123" :: ByteString)
             `shouldThrow` (== userError "DATABASE_URL is missing path")
     it "should handle missing authentication" $
-        fromDatabaseUrl 10 "postgres://example/db"
+        fromDatabaseUrl 10 ("postgres://example/db" :: ByteString)
             `shouldThrow` (== userError "DATABASE_URL is missing user info")
     it "should handle a different protocol" $
-        fromDatabaseUrl 10 "mysql://user:pass@example:123/db"
+        fromDatabaseUrl 10 ("mysql://user:pass@example:123/db" :: ByteString)
             `shouldThrow` (== userError "DATABASE_URL has unknown scheme")


### PR DESCRIPTION
When parsing JSON/YAML, database URLs will likely be found as Text.
