### PR TITLE
Make the package build with Stack LTS 6.4

### DIFF
--- a/src/Database/Persist/URL.hs
+++ b/src/Database/Persist/URL.hs
@@ -15,7 +15,7 @@ import URI.ByteString
     ( Authority(..)
     , Host(..)
     , Port(..)
-    , URI(..)
+    , URIRef(..)
     , UserInfo(..)
     , Scheme(..)
     , parseURI

--- a/src/Database/Persist/URL.hs
+++ b/src/Database/Persist/URL.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Database.Persist.URL
     ( fromDatabaseUrl
     ) where
@@ -15,7 +16,11 @@ import URI.ByteString
     ( Authority(..)
     , Host(..)
     , Port(..)
+#if MIN_VERSION_uri_bytestring(0,2,0)
     , URIRef(..)
+#else
+    , URI(..)
+#endif
     , UserInfo(..)
     , Scheme(..)
     , parseURI

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.11
+resolver: lts-6.3
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.3
+resolver: lts-6.4
 
 packages:
 - '.'


### PR DESCRIPTION
LTS 6.4 is the latest version.

```
persistent-database-url/src/Database/Persist/URL.hs:33:40:
    Not in scope: ‘uriAuthority’
    Perhaps you meant data constructor ‘Authority’ (imported from URI.ByteString)
```

Unfortunately, it fails to build on LTS 5.11:

```
Module ‘URI.ByteString’ does not export ‘URIRef(..)’
```
