### PR TITLE
Disable all Travis email (e.g. on failed builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 sudo: false
+email: false
 cache:
   directories:
   - $HOME/.stack/


### PR DESCRIPTION
- It's annoying
- It's not very useful
